### PR TITLE
Fixed the Discord link

### DIFF
--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -53,7 +53,7 @@ const ContactsPage = () => {
             <ContactsListItem
               platform='Discord'
               description='Angelo#0420'
-              url='https://discord.com/channels/@me/189769721653100546'
+              url='https://discord.com/users/189769721653100546'
             />
             <ContactsListItem
               platform='Telegram'


### PR DESCRIPTION
# Expected behaviour 
* Display @angeloanan Discord profile.

# The error
![](https://i.imgur.com/byNUuvz.png)

# The fix
* I replaced the link `https://discord.com/channels/@me/189769721653100546` with the working one `https://discord.com/users/189769721653100546`
* Displays the correct screen!

![image](https://user-images.githubusercontent.com/59417077/134780375-ee465b86-454c-4018-949b-c933ef15a0d7.png)